### PR TITLE
Bring inlining up to speed

### DIFF
--- a/src/internal.hh
+++ b/src/internal.hh
@@ -36,8 +36,8 @@ namespace whilelang {
 	// Inlining
     PassDef build_call_graph(std::shared_ptr<CallGraph> call_graph);
     PassDef inlining(
-        std::shared_ptr<CallGraph> &call_graph,
-        std::shared_ptr<ControlFlow> &cfg);
+        std::shared_ptr<CallGraph> call_graph,
+        std::shared_ptr<ControlFlow> cfg);
 
 	// Compilation
 	PassDef to3addr();

--- a/src/passes/build_call_graph.cc
+++ b/src/passes/build_call_graph.cc
@@ -11,7 +11,7 @@ namespace whilelang {
             while (curr != FunDef) {
                 curr = curr->parent();
             }
-            return (curr / FunId) / Ident;
+            return curr / FunId;
         };
 
         PassDef pass = {
@@ -20,7 +20,7 @@ namespace whilelang {
             dir::topdown | dir::once,
             {
                 T(FunCall)[FunCall] >> [=](Match &_) -> Node {
-                    auto caller = (_(FunCall) / FunId) / Ident;
+                    auto caller = _(FunCall) / FunId;
                     auto surronding_fun = find_surronding_fun(_(FunCall));
 
                     call_graph->add_vertex(caller);

--- a/src/passes/inlining.cc
+++ b/src/passes/inlining.cc
@@ -5,8 +5,8 @@ namespace whilelang {
     using namespace trieste;
 
     PassDef inlining(
-        std::shared_ptr<CallGraph> &call_graph,
-        std::shared_ptr<ControlFlow> &cfg) {
+        std::shared_ptr<CallGraph> call_graph,
+        std::shared_ptr<ControlFlow> cfg) {
         // Creates assignments for the parameters of the function call
         auto assign_params = [](Node &params, Node &args) -> Node {
             Node builder = Stmt;
@@ -34,7 +34,7 @@ namespace whilelang {
                 T(Stmt)
                         << (T(Assign) << T(Ident)[Ident] *
                                 (T(AExpr) << T(FunCall)[FunCall])) >>
-                    [&](Match &_) -> Node {
+                    [=](Match &_) -> Node {
                     auto fun_call = _(FunCall);
                     auto fun_id = get_identifier((fun_call / FunId) / Ident);
 

--- a/src/passes/inlining.cc
+++ b/src/passes/inlining.cc
@@ -36,7 +36,8 @@ namespace whilelang {
                                 (T(AExpr) << T(FunCall)[FunCall])) >>
                     [=](Match &_) -> Node {
                     auto fun_call = _(FunCall);
-                    auto fun_id = get_identifier((fun_call / FunId) / Ident);
+                    auto fun_id = get_identifier(fun_call / FunId);
+
 
                     if (call_graph->can_fun_be_inlined(fun_id)) {
                         cfg->set_dirty_flag(true);
@@ -87,18 +88,19 @@ namespace whilelang {
                 },
 
                 T(Inlining) << T(If)[If] >> [](Match &_) -> Node {
-                    auto bexpr = _(If) / BExpr;
+                    auto batom = _(If) / BAtom;
                     auto then_stmt = _(If) / Then;
                     auto else_stmt = _(If) / Else;
 
-                    return If << bexpr << (Inlining << then_stmt)
+                    return If << batom << (Inlining << then_stmt)
                               << (Inlining << else_stmt);
                 },
 
                 T(Inlining) << T(While)[While] >> [](Match &_) -> Node {
-                    auto bexpr = _(While) / BExpr;
+                    auto cond_stmt = _(While) / Stmt;
+                    auto batom = _(While) / BAtom;
                     auto do_stmt = _(While) / Do;
-                    return While << bexpr << (Inlining << do_stmt);
+                    return While << (Inlining << cond_stmt) << batom << (Inlining << do_stmt);
                 },
 
                 T(Inlining) << T(Assign, Skip, Output, Var)[Stmt] >>


### PR DESCRIPTION
This PR fixes a memory error relating to shared pointers and adapts inlining to the latest WF